### PR TITLE
Add convenience install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,17 @@ Finally, you'll have to bring up the new service using
 brewblox-ctl up
 ```
 
+### Alternative: Install script
+
+To automate the above steps, you can also run the `tilt_installer.py` script.
+This will create the ./tilt directory, and edit your `docker-compose.yml` file.
+
+Copy the `tilt_installer.py` file to your brewblox directory, and run it with
+
+```bash
+python3 ./tilt_installer.py
+```
+
 ### Add to your graphs
 
 Once the Tilt service receives data from your Tilt(s), it should be available as graph metrics in BrewBlox.

--- a/tilt_installer.py
+++ b/tilt_installer.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Convenience installation script for adding a Tilt service to a BrewBlox installation.
+
+It must be run in the BrewBlox install directory.
+
+Steps:
+- Creates the ./tilt directory.
+- Append the tilt service to ./docker-compose.yml.
+- Modify the eventbus service to publish port 5672 on the host.
+
+Notes:
+
+- Python >= 3.5 is required to run.
+- This scripts depends on the pyyaml package.
+    The package is assumed to be there, as it's also brewblox-ctl dependency.
+- No calibration files are added or modified.
+"""
+
+from os import makedirs, path
+from platform import machine
+from subprocess import check_call
+
+import yaml
+
+
+def main():
+    tilt_dir = path.abspath('./tilt')
+    compose_file = path.abspath('./docker-compose.yml')
+
+    if not path.exists(compose_file):
+        raise SystemExit('ERROR: Compose file not found in current directory. '
+                         'Please navigate to your brewblox directory first.')
+
+    print('Creating ./tilt directory...')
+    if not path.exists(tilt_dir):
+        makedirs(tilt_dir)
+
+    print('Editing docker-compose.yml file...')
+    with open(compose_file) as f:
+        config = yaml.safe_load(f)
+
+    tag = 'rpi-latest' if machine().startswith('arm') else 'latest'
+
+    config['services']['tilt'] = {
+        'image': 'j616s/brewblox-tilt:{}'.format(tag),
+        'restart': 'unless_stopped',
+        'privileged': True,
+        'depends_on': ['history'],
+        'network_mode': 'host',
+        'command': '-p 5001 --eventbus-host=172.17.0.1',
+        'volumes': ['./tilt:/share']
+    }
+    config['services']['eventbus']['ports'] = ['5672:5672']
+
+    with open(compose_file, 'w') as f:
+        yaml.safe_dump(config, f)
+
+    print('Restarting services...')
+    check_call('brewblox-ctl restart', shell=True)
+
+
+if __name__ == '__main__':
+    main()

--- a/tilt_installer.py
+++ b/tilt_installer.py
@@ -45,7 +45,7 @@ def main():
 
     config['services']['tilt'] = {
         'image': 'j616s/brewblox-tilt:{}'.format(tag),
-        'restart': 'unless_stopped',
+        'restart': 'unless-stopped',
         'privileged': True,
         'depends_on': ['history'],
         'network_mode': 'host',


### PR DESCRIPTION
Based on https://community.brewpi.com/t/edge-release-2019-10-01/4020/6

Compose files can be scary, and the Tilt doesn't really have any user-specific configuration. This lends it well to having a install script that spits out a default configuration.