### PR TITLE
Reset from docker

### DIFF
--- a/brewblox_tilt/tiltScanner.py
+++ b/brewblox_tilt/tiltScanner.py
@@ -252,7 +252,6 @@ class TiltScanner(features.ServiceFeature):
         LOGGER.info('Started TiltScanner')
 
         while self.scanning:
-            self.resetBT = False
             try:
                 sock = bluez.hci_open_dev(0)
 
@@ -263,7 +262,7 @@ class TiltScanner(features.ServiceFeature):
             blescan.hci_enable_le_scan(sock)
 
             # Keep scanning until the manager is told to stop.
-            while self.scanning and not self.resetBT:
+            while self.scanning:
                 self._processSocket(sock)
                 await self._publishMessage()
 
@@ -274,10 +273,10 @@ class TiltScanner(features.ServiceFeature):
         except KeyboardInterrupt:
             self.scanning = False
         except Exception as e:
-            self.resetBT = True
+            self.scanning = False
             LOGGER.error(
                 f"Error accessing bluetooth device whilst scanning: {e}")
-            LOGGER.error("Resetting Bluetooth device")
+            LOGGER.error("Exiting")
 
     async def _publishMessage(self):
         try:

--- a/brewblox_tilt/tiltScanner.py
+++ b/brewblox_tilt/tiltScanner.py
@@ -251,20 +251,19 @@ class TiltScanner(features.ServiceFeature):
 
         LOGGER.info('Started TiltScanner')
 
+        try:
+            sock = bluez.hci_open_dev(0)
+
+        except Exception as e:
+            LOGGER.error(f"Error accessing bluetooth device: {e}")
+            sys.exit(1)
+
+        blescan.hci_enable_le_scan(sock)
+
+        # Keep scanning until the manager is told to stop.
         while self.scanning:
-            try:
-                sock = bluez.hci_open_dev(0)
-
-            except Exception as e:
-                LOGGER.error(f"Error accessing bluetooth device: {e}")
-                sys.exit(1)
-
-            blescan.hci_enable_le_scan(sock)
-
-            # Keep scanning until the manager is told to stop.
-            while self.scanning:
-                self._processSocket(sock)
-                await self._publishMessage()
+            self._processSocket(sock)
+            await self._publishMessage()
 
     def _processSocket(self, sock):
         try:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='brewblox-tilt',
-    version='1.2.1',
+    version='1.2.2',
     long_description="Tilt hydrometer service for BrewBlox",
     url='https://github.com/j616/brewblox-tilt',
     author='James Sandford',


### PR DESCRIPTION
When bluetooth fails, resetting it from within python doesn't work. Instead, this exits the program, which exits the container, which triggers a restart...