### PR TITLE
Fix install script and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This will create the ./tilt directory, and edit your `docker-compose.yml` file.
 In your BrewBlox directory, run the following commands:
 
 ```bash
-curl -o https://raw.githubusercontent.com/j616/brewblox-tilt/develop/install_tilt.py
+curl -O https://raw.githubusercontent.com/j616/brewblox-tilt/develop/install_tilt.py
 python3 ./install_tilt.py
 ```
 

--- a/install_tilt.py
+++ b/install_tilt.py
@@ -67,6 +67,10 @@ def install():
         'command': '--name tilt --port 5001 --eventbus-host=172.17.0.1',
         'volumes': ['./tilt:/share']
     }
+
+    if not 'eventbus' in config['services']:
+        config['services']['eventbus'] = {}
+
     config['services']['eventbus']['ports'] = ['5672:5672']
 
     with open(compose_file, 'w') as f:

--- a/install_tilt.py
+++ b/install_tilt.py
@@ -68,7 +68,7 @@ def install():
         'volumes': ['./tilt:/share']
     }
 
-    if not 'eventbus' in config['services']:
+    if 'eventbus' not in config['services']:
         config['services']['eventbus'] = {}
 
     config['services']['eventbus']['ports'] = ['5672:5672']


### PR DESCRIPTION
The install_tilt.py script crashes with a KeyError on `config['services']['eventbus']['ports'] = ['5672:5672']` because by default there is no eventbus section in docker-compose.yml (moved to docker-compose.shared.yml in recent releases). Added checking for this key.

I also fixed a typo with the curl parameters in the installation instructions