### PR TITLE
enable ARM64 builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 pool:
-  vmImage: 'Ubuntu-18.04'
+  vmImage: 'Ubuntu-20.04'
 
 trigger:
   tags:
@@ -48,24 +48,18 @@ steps:
   displayName: Run Pytest
 
 - bash: |
-    curl -L -o ~/.docker/cli-plugins/docker-buildx --create-dirs ${BUILDX_URL}
-    chmod a+x ~/.docker/cli-plugins/docker-buildx
-    docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
-    docker buildx create --use
-    docker buildx inspect --bootstrap
+    curl -fsSL https://raw.githubusercontent.com/BrewBlox/deployed-images/develop/prepare_buildx.sh | bash
   displayName: Prepare buildx
-  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
-  env:
-    BUILDX_URL: https://github.com/docker/buildx/releases/download/v0.3.1/buildx-v0.3.1.linux-amd64
+  condition: and(succeeded(), variables.BRANCH)
 
 - bash: echo $(DOCKER_PASSWORD) | docker login -u $(DOCKER_USER) --password-stdin
   displayName: Docker login
-  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+  condition: and(succeeded(), variables.BRANCH)
 
 - bash: bash ./before_build.sh
   displayName: Run before_build.sh script
   workingDirectory: docker
-  condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+  condition: and(succeeded(), variables.BRANCH)
 
 - bash: >-
     docker buildx build
@@ -73,7 +67,7 @@ steps:
     --tag $(DOCKER_REPO):rpi-$(TAG)
     --build-arg service_info="$(git describe) @ $(date)"
     --push
-    --platform linux/amd64,linux/arm/v7
+    --platform linux/amd64,linux/arm/v7,linux/arm64/v8
     docker
   displayName: Deploy Docker images with branch tags
   condition: and(succeeded(), variables['BRANCH'])


### PR DESCRIPTION
Based on https://community.brewpi.com/t/installing-brewblox-on-ubuntu-20-04-on-raspberry-pi/4363/11?u=bob_steers

Availability of ARM64 wheels improved to the point where builds now only take ~10m longer. With the switch to Redis, all our third-party images are now also available in ARM64.

Also updated the CI file to reduce boilerplate by importing the prepare_buildx.sh script. 